### PR TITLE
Minor spelling mistake, changed `calss` to `class`

### DIFF
--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -167,7 +167,7 @@ typedef void (*pkDeleteInstanceFn) (PKVM* vm, void*);
 /*****************************************************************************/
 
 // Type enum of the pocketlang's first class types. Note that Object isn't
-// instanciable (as of now) but they're considered first calss.
+// instanciable (as of now) but they're considered first class.
 enum PkVarType {
   PK_OBJECT = 0,
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typographical error in a comment from "first calss" to "first class."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->